### PR TITLE
Update README.md

### DIFF
--- a/interfaces/README.md
+++ b/interfaces/README.md
@@ -10,8 +10,8 @@ The language bindings are generated using SWIG. To build them, you need to insta
 
 * Linux / Mac:
 ```
-wget http://www.swig.org/download.htmlhttp://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz
-tar zxvf swig-3.0.12.tar.gz && cd swig-3.0.12.tar
+wget http://www.swig.org/download.html http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz
+tar zxvf swig-3.0.12.tar.gz && cd swig-3.0.12
 ./configure --without-pcre && make && sudo make install
 
 # May be required on some Linux systems (replace VERSION with the actual version on your system)


### PR DESCRIPTION
Fixed typos in the Linux/Mac install instructions for SWIG. Missing space between addresses and removed .tar where it wasn't needed.