### PR TITLE
Notes for CMake on Ubuntu 16.04 and 17.04

### DIFF
--- a/INSTALL-Ubuntu.md
+++ b/INSTALL-Ubuntu.md
@@ -20,7 +20,9 @@ Next, you will need *gcc* and [*CMake*](https://cmake.org/). They are often inst
 
     sudo apt-get install -y gcc cmake
 
-The current version on Ubuntu is 3.7.2, but build may require version 3.9 (which is currently in rc5). To get version 3.9.x 
+The current version of CMake on Ubuntu 16.04 is 3.5.1, which appears to build just fine. 
+
+On Ubuntu 17.04, CMake is version 3.7.2, but build may require version 3.9 (which is currently in rc5). To get version 3.9.x 
     
     wget https://cmake.org/files/v3.9/cmake-3.9.0-rc5.tar.gz
     tar zxvf cmake-3.9.0-rc5.tar.gz && cd cmake-3.9.0-rc5

--- a/INSTALL-Ubuntu.md
+++ b/INSTALL-Ubuntu.md
@@ -20,6 +20,14 @@ Next, you will need *gcc* and [*CMake*](https://cmake.org/). They are often inst
 
     sudo apt-get install -y gcc cmake
 
+The current version on Ubuntu is 3.7.2, but build may require version 3.9 (which is currently in rc5). To get version 3.9.x 
+    
+    wget https://cmake.org/files/v3.9/cmake-3.9.0-rc5.tar.gz
+    tar zxvf cmake-3.9.0-rc5.tar.gz && cd cmake-3.9.0-rc5
+    ./bootstrap
+    make
+    sudo make install
+
 ##### LLVM
 You will also need the dev version of [*LLVM-3.9*](http://llvm.org/). At the time of writing this document, `apt-get` doesn't yet have the required version of LLVM. To check this, type
 


### PR DESCRIPTION
I had problems building on 17.04 with the default CMake (3.7.2) so upgraded to 3.9.0.rc5. Added notes about how to update to version 3.9.
Building on 16.04 with default CMake version of 3.5.1 went just swimmingly. Noted this as well.