### PR TITLE
Update README.md -clarified language for python binding install

### DIFF
--- a/interfaces/README.md
+++ b/interfaces/README.md
@@ -49,7 +49,7 @@ make _ELL_python
 cmake --build . --target _ELL_python --config Release
 ```
 
-Note: if you already built ELL before you installed Python, you will need to delete that build and repeat the above steps
+Note: if you already built ELL before, you will need to delete that build and repeat the above steps
 in order to ensure the build is correctly setup to do the additional Python related build steps.
 
 4. Test the python bindings, which are located in build/interfaces/python/test:


### PR DESCRIPTION
clarified language regarding python binding install... I already had python installed when I did the initial cmake and make, but when I came here do do the make _ELL_Python, some things were not set up so the test.py file failed silently. I purged the build folder and started again at step 3 here, and now test.py works.