### PR TITLE
Add a switch to select Visual Studio version

### DIFF
--- a/rebuild.cmd
+++ b/rebuild.cmd
@@ -10,13 +10,23 @@ mkdir build
 if ERRORLEVEL 1 goto :nodelete
 
 cd build
+
+set /p vs="Enter your Visual Studio version (2015/2017): "
+if %vs% == 2017 goto :2017
+
+if not %vs% == 2015 goto :builderror
 cmake -G "Visual Studio 14 2015 Win64" -DPROCESSOR_HINT=haswell ..
 if ERRORLEVEL 1 goto :nocmake
+goto :build
 
-cmake --build . --config RelWithDebInfo
+:2017
+cmake -G "Visual Studio 15 2017 Win64" -DPROCESSOR_HINT=haswell ..
+
+:build
+cmake --build . --config Release
 if ERRORLEVEL 1 goto :builderror
 
-cmake --build . --target _ELL_python --config RelWithDebInfo
+cmake --build . --target _ELL_python --config Release
 
 goto :eof
 


### PR DESCRIPTION
RelWithDebInfo breaks a lot of scripts looking at Release and Debug folders, so I changed it to Release config and added a switch for vstudio 2015/2017