### PR TITLE
Fixed stale brew tap, added LLVMDIR workaround

### DIFF
--- a/CMake/OpenBLASSetup.cmake
+++ b/CMake/OpenBLASSetup.cmake
@@ -58,13 +58,28 @@ if(NOT WIN32)
         /opt/OpenBLAS/include
         /System/Library/Frameworks/Accelerate.framework/Versions/Current/Frameworks/vecLib.framework/Versions/Current/Headers/
         /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework/Frameworks/vecLib.framework/Headers/
+        /usr/local/Cellar/openblas/0.2.20_1/include
         /usr/include
         /usr/local/include
         /usr/include/openblas
     )
 
     set(BLAS_LIB_SEARCH_PATHS
-        /opt/OpenBLAS/lib /usr/lib64/atlas-sse3 /usr/lib64/atlas /usr/lib64 /usr/local/lib64/atlas /usr/local/lib64 /usr/lib/atlas-sse3 /usr/lib/atlas-sse2 /usr/lib/atlas-sse /usr/lib/atlas-3dnow /usr/lib/atlas /usr/lib /usr/local/lib/atlas /usr/local/lib
+        /opt/OpenBLAS/lib
+        /usr/local/Cellar/openblas/0.2.20_1/lib
+        /usr/lib64/atlas-sse3
+        /usr/lib64/atlas
+        /usr/lib64
+        /usr/local/lib64/atlas
+        /usr/local/lib64
+        /usr/lib/atlas-sse3
+        /usr/lib/atlas-sse2
+        /usr/lib/atlas-sse
+        /usr/lib/atlas-3dnow
+        /usr/lib/atlas
+        /usr/lib
+        /usr/local/lib/atlas
+        /usr/local/lib
     )
 endif()
 

--- a/INSTALL-Mac.md
+++ b/INSTALL-Mac.md
@@ -133,22 +133,6 @@ Try telling CMake where to find LLVM as follows:
 cmake -DLLVM_DIR=/usr/local/Cellar/llvm@3.9/3.9.1_1/lib/cmake/llvm ..
 ```
 
-**ELL/libraries/model/include/IRModelProfiler.h:15:10: fatal error: 'EmitterTypes.h' file not found #include "EmitterTypes.h"**
-
-This error has been reported and a possible work around is to create a symbolic link from llvm@3.9 to the llvm folder as follows:
-
-```shell
-cd /usr/local/Cellar/llvm
-ln -s ../llvm@3.9/3.9.1_1
-```
-
-Then make sure you're using that version using this command:
-
-```shell
-brew switch llvm 3.9.1_1
-```
-
-
 ## Advanced Installation
 
 The instructions above are enough to start using ELL. For more advanced topics, like testing and generating documentation, please see our [advanced installation instructions](INSTALL-Advanced.md).

--- a/INSTALL-Mac.md
+++ b/INSTALL-Mac.md
@@ -62,7 +62,7 @@ To install all of the above, type
 ```shell
 brew install cmake
 brew install swig
-brew install homebrew/science/openblas
+brew install openblas
 brew install doxygen
 ```
 
@@ -124,6 +124,14 @@ make _ELL_python
 The generated executables will appear in `ELL/build/bin`.
 
 ## Troubleshooting
+
+**LLVM not found, please check that LLVM is installed.**
+
+Try telling CMake where to find LLVM as follows:
+
+```shell
+cmake -DLLVM_DIR=/usr/local/Cellar/llvm@3.9/3.9.1_1/lib/cmake/llvm ..
+```
 
 **ELL/libraries/model/include/IRModelProfiler.h:15:10: fatal error: 'EmitterTypes.h' file not found #include "EmitterTypes.h"**
 


### PR DESCRIPTION
* homebrew/science/openblas is not longer valid.  This has migrated over to [homebrew-core](https://github.com/Homebrew/homebrew-core/blob/3405b293d63bff1e81040032391fbc1756cf1721/Formula/openblas.rb) which is up to the latest release of OpenBlas
  * The version in OpenBLASSetup.cmake is hardcoded, which I'm not super happy with, but I can't think of a cleaner way that doesn't require the user to setup a symlink.
* for a clean setup on macOS sierra, CMake can't find LLVM. Tried creating a symlink in /user/local/Cellar/llvm to llvm@3.9 to no avail.
* cleaned up troubleshooting instruction that no longer applies