### PR TITLE
Fix make_profile build break on Linux docker images

### DIFF
--- a/libraries/common/include/MapCompilerArguments.h
+++ b/libraries/common/include/MapCompilerArguments.h
@@ -46,6 +46,7 @@ namespace common
         int maxThreads = 4;
         bool debug = false;
         PreferredConvolutionMethod convolutionMethod = PreferredConvolutionMethod::none; // known methods: none, unrolled, simple, diagonal, winograd
+        bool positionIndependentCode = false; // for generating -fPIC object code
 
         // target machine options
         std::string target = ""; // known target names: host, mac, linux, windows, pi0, pi3, pi3_64, aarch64, ios

--- a/libraries/common/src/MapCompilerArguments.cpp
+++ b/libraries/common/src/MapCompilerArguments.cpp
@@ -155,6 +155,13 @@ namespace common
             "",
             "A string describing target-specific features to enable or disable (these are LLVM attributes, in the format the llc -mattr option uses)",
             "");
+
+        parser.AddOption(
+            positionIndependentCode,
+            "positionIndependentCode",
+            "pic",
+            "Generate position independent code (equivalent to -fPIC)",
+            false);
     }
 
     model::MapCompilerOptions MapCompilerArguments::GetMapCompilerOptions(const std::string& modelName) const
@@ -196,6 +203,7 @@ namespace common
         settings.optimizerSettings.preferredConvolutionMethod = convolutionMethod;
         settings.profile = profile;
         settings.compilerSettings.profile = profile;
+        settings.compilerSettings.positionIndependentCode = positionIndependentCode;
 
         if (target != "")
         {

--- a/libraries/emitters/include/CompilerOptions.h
+++ b/libraries/emitters/include/CompilerOptions.h
@@ -38,6 +38,7 @@ namespace emitters
         bool useThreadPool = true;
         int maxThreads = 4;
         bool debug = false;
+        bool positionIndependentCode = false;
 
         TargetDevice targetDevice;
     };

--- a/libraries/emitters/include/IRAssemblyWriter.h
+++ b/libraries/emitters/include/IRAssemblyWriter.h
@@ -32,6 +32,9 @@ namespace emitters
     /// <summary> An enum containing the type of output to generate {CGFT_AssemblyFile, CGFT_ObjectFile, CGFT_Null} </summary>
     typedef llvm::TargetMachine::CodeGenFileType OutputFileType;
 
+    /// <summary> An enum containing the relocation model of the LLVM machine code output {Static, PIC_, DynamicNoPIC, ROPI, RWPI, ROPI_RWPI} </summary>
+    typedef llvm::Reloc::Model OutputRelocationModel;
+
     /// <summary> Options for LLVM machine code output (assembly or object code) </summary>
     struct MachineCodeOutputOptions
     {
@@ -43,6 +46,7 @@ namespace emitters
         OptimizationLevel optimizationLevel = OptimizationLevel::Default;
         FloatABIType floatABI = FloatABIType::Default;
         FloatFusionMode floatFusionMode = FloatFusionMode::Standard;
+        OutputRelocationModel relocModel = OutputRelocationModel::Static;
     };
 
     /// <summary> Indicates if the requested output type is binary or text </summary>

--- a/libraries/emitters/src/IRAssemblyWriter.cpp
+++ b/libraries/emitters/src/IRAssemblyWriter.cpp
@@ -137,7 +137,7 @@ namespace emitters
         targetOptions.MCOptions.AsmVerbose = ellOptions.verboseOutput;
         targetOptions.FloatABIType = ellOptions.floatABI;
 
-        llvm::Reloc::Model relocModel = llvm::Reloc::Static;
+        llvm::Reloc::Model relocModel = ellOptions.relocModel;
         llvm::CodeModel::Model codeModel = llvm::CodeModel::Default;
 
         std::unique_ptr<llvm::TargetMachine> targetMachine(target->createTargetMachine(module.getTargetTriple(),

--- a/libraries/emitters/src/IRModuleEmitter.cpp
+++ b/libraries/emitters/src/IRModuleEmitter.cpp
@@ -795,6 +795,10 @@ namespace emitters
         {
             options.optimizationLevel = OptimizationLevel::Aggressive;
         }
+        if (compilerOptions.positionIndependentCode)
+        {
+            options.relocModel = OutputRelocationModel::PIC_;
+        }
         // Other params to possibly set:
         //   bool verboseOutput = false;
         //   bool verifyModule = false;

--- a/tools/utilities/profile/make_profiler.sh.in
+++ b/tools/utilities/profile/make_profiler.sh.in
@@ -56,6 +56,7 @@ if [ ${next_opt:0:1} != '-' ] ; then
 fi
 
 # Platform-specific options
+compile_opts=""
 generic_llc_opts="-relocation-model=pic"
 pi3_llc_opts="-relocation-model=pic -mtriple=armv7-linux-gnueabihf -mcpu=cortex-a53"
 pi0_llc_opts="-relocation-model=pic -mtriple=arm-linux-gnueabihf -mcpu=arm1176jzf-s"
@@ -66,11 +67,14 @@ fi
 if [ ${target} == 'pi0' ] ; then
     llc_opts=$pi0_llc_opts
 fi
+if [ ${target} == 'host' ] ; then
+    compile_opts="--positionIndependentCode"
+fi
 
 echo "Compiling model profilers to ${profiler_directory}"
 mkdir -p $profiler_directory
-@COMPILE_EXECUTABLE@ $model_option $model_file --profile --ir --objectCode --header -od $profiler_directory -ob compiled_model $@
-@COMPILE_EXECUTABLE@ $model_option $model_file --ir --objectCode --header -od $profiler_directory -ob compiled_model_noprofile $@
+@COMPILE_EXECUTABLE@ $model_option $model_file --profile --ir --objectCode $compile_opts --header -od $profiler_directory -ob compiled_model $@
+@COMPILE_EXECUTABLE@ $model_option $model_file --ir --objectCode $compile_opts --header -od $profiler_directory -ob compiled_model_noprofile $@
 
 cd $profiler_directory
 @OPT_EXECUTABLE@ compiled_model.ll -o compiled_model_opt.ll -O3 -S


### PR DESCRIPTION
Compile.exe currently defaults to emitting non-relocatable object code. On docker images running ubuntu, this will fail to link with other object code that's built using -fPIC.  In addition, LLVM opt.exe is already called to emit position independent code, so compile.exe's behavior is inconsistent.

This change adds an optional flag to compile.exe to emit positionIndependent code. This is called in make_profile.sh.  The default behavior (static code) still holds in other use cases.

```
34: -- Build files have been written to: /ELL/build/unrolled_64x64x4x8_test_profiler/build
34: Scanning dependencies of target exercise_model
34: [ 10%] Building CXX object CMakeFiles/exercise_model.dir/CompiledExerciseModel_main.cpp.o
34: [ 20%] Linking CXX executable exercise_model
34: /usr/bin/ld: ../compiled_model.o: relocation R_X86_64_32S against `.bss' can not be used when making a shared object; recompile with -fPIC
34: /usr/bin/ld: final link failed: Nonrepresentable section on output
34: collect2: error: ld returned 1 exit status
34: CMakeFiles/exercise_model.dir/build.make:96: recipe for target 'exercise_model' failed
34: make[2]: *** [exercise_model] Error 1
34: CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/exercise_model.dir/all' failed
34: make[1]: *** [CMakeFiles/exercise_model.dir/all] Error 2
34: Makefile:83: recipe for target 'all' failed
```
[Full log](https://api.travis-ci.com/v3/job/124493164/log.txt)