### PR TITLE
Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+
+services:
+  - docker
+
+install:
+  - export TRAVIS_REPO_OWNER=${TRAVIS_REPO_SLUG%/*}
+  - export TRAVIS_REPO_NAME=${TRAVIS_REPO_SLUG#*/}
+  - export REPO=https://github.com/$TRAVIS_REPO_OWNER/ELL.git
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"  
+  - docker build -t microsoft/ell:latest --build-arg branch=$BRANCH --build-arg repo=$REPO .
+
+script:
+  # hack to install openmpi because docker runs out of memory
+  - docker run -it microsoft/ell:latest /bin/sh -c 'cd /openmpi-1.10.3; make -j all; make install; cd /ELL/build; ctest -VV'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
   - docker pull $DOCKERHUB_ACCOUNT/ell-build:latest
 
 script:
-  - docker run -it $DOCKERHUB_ACCOUNT/ell-build:latest -v $TRAVIS_BUILD_DIR:/ELL /bin/sh -c 'cd /ELL; ./build.sh; cd build; ctest -VV'
+  - docker run -v $TRAVIS_BUILD_DIR:/ELL -it $DOCKERHUB_ACCOUNT/ell-build:latest /bin/sh -c 'cd /ELL; ./build.sh; cd build; ctest -VV'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,8 @@ services:
   - docker
 
 install:
-  - export TRAVIS_REPO_OWNER=${TRAVIS_REPO_SLUG%/*}
-  - export TRAVIS_REPO_NAME=${TRAVIS_REPO_SLUG#*/}
-  - export REPO=https://github.com/$TRAVIS_REPO_OWNER/ELL.git
-  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"  
-  - docker build -t microsoft/ell:latest --build-arg branch=$BRANCH --build-arg repo=$REPO .
+  - export DOCKERHUB_ACCOUNT=lisaong
+  - docker pull $DOCKERHUB_ACCOUNT/ell-build:latest
 
 script:
-  # hack to install openmpi because docker runs out of memory
-  - docker run -it microsoft/ell:latest /bin/sh -c 'cd /openmpi-1.10.3; make -j all; make install; cd /ELL/build; ctest -VV'
+  - docker run -it $DOCKERHUB_ACCOUNT/ell-build:latest -v $TRAVIS_BUILD_DIR:/ELL /bin/sh -c 'cd /ELL; ./build.sh; cd build; ctest -VV'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
-# Dockerfile for an Ubuntu environment for ELL
+# Dockerfile for an Ubuntu environment for ELL for Continuous Integration
 FROM continuumio/miniconda3:latest
-
-ARG branch=master
-ARG repo=https://github.com/Microsoft/ELL.git
 
 RUN apt-get update \
     && apt-get install -y \
       build-essential \
-      cmake \
       curl \
       gcc \
       git \
@@ -51,24 +47,16 @@ RUN /bin/bash -c "source activate base" \
 RUN curl -o openmpi-1.10.3.tar.gz -L https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.3.tar.gz \
     && tar zxvf openmpi-1.10.3.tar.gz \
     && cd openmpi-1.10.3 \
-    && ./configure --prefix=/usr/local/mpi
-
-# Moved to the docker run stage.
-# (running it here can exhaust virtual memory on Travis-CI docker builds)
-# WORKDIR /openmpi-1.10.3
-# RUN make -j all \
-#    && make install
-# WORKDIR /
+    && ./configure --prefix=/usr/local/mpi \
+    && make -j all \
+    && make install
 
 # LD path to libpython3.6m.so
 RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && \
     ldconfig
 
-# ELL
-RUN git clone -b $branch $repo \
-    && cd ELL \
-    && mkdir -p build \
-    && cd build \
-    && cmake .. \
-    && make \
-    && make _ELL_python
+# cmake
+RUN curl -o cmake-3.11.2-Linux-x86_64.sh -L https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.sh \
+    && chmod +x cmake-3.11.2-Linux-x86_64.sh \
+    && ./cmake-3.11.2-Linux-x86_64.sh --skip-license \
+    &&  ln -s /opt/cmake-3.11.2-Linux-x86_64/bin/* /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+# Dockerfile for an Ubuntu environment for ELL
+FROM continuumio/miniconda3:latest
+
+ARG branch=master
+ARG repo=https://github.com/Microsoft/ELL.git
+
+RUN apt-get update \
+    && apt-get install -y \
+      build-essential \
+      cmake \
+      curl \
+      gcc \
+      git \
+      libedit-dev \
+      zlibc \
+      zlib1g \
+      zlib1g-dev \
+      libopenblas-dev \
+      doxygen \
+      unzip \
+    && apt-get clean all
+
+# LLVM
+RUN apt-get update \
+    && apt-get install -y \
+      llvm-3.9-dev \
+    && apt-get clean all
+
+# SWIG
+RUN curl -O --location http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz \
+    && tar zxvf swig-3.0.12.tar.gz \
+    && cd swig-3.0.12 \
+    && ./configure --without-pcre \
+    && make \
+    && make install
+
+# OpenCV
+RUN apt-get update \
+    && apt-get install -y \
+       libgl1-mesa-glx
+RUN export PATH="/opt/conda/bin:${PATH}" \
+    && conda install --yes --quiet -c conda-forge opencv
+
+# CNTK
+RUN /bin/bash -c "source activate base" \
+    && pip install --upgrade pip \
+    && pip install --no-cache-dir --ignore-installed \
+          cntk
+
+# OpenMPI
+RUN curl -o openmpi-1.10.3.tar.gz -L https://www.open-mpi.org/software/ompi/v1.10/downloads/openmpi-1.10.3.tar.gz \
+    && tar zxvf openmpi-1.10.3.tar.gz \
+    && cd openmpi-1.10.3 \
+    && ./configure --prefix=/usr/local/mpi
+
+# Moved to the docker run stage.
+# (running it here can exhaust virtual memory on Travis-CI docker builds)
+# WORKDIR /openmpi-1.10.3
+# RUN make -j all \
+#    && make install
+# WORKDIR /
+
+# LD path to libpython3.6m.so
+RUN echo /opt/conda/lib >> /etc/ld.so.conf.d/conda.conf && \
+    ldconfig
+
+# ELL
+RUN git clone -b $branch $repo \
+    && cd ELL \
+    && mkdir -p build \
+    && cd build \
+    && cmake .. \
+    && make \
+    && make _ELL_python


### PR DESCRIPTION
Propose adding Travis CI support to the ELL Github repository:
- Pulls a docker (ubuntu) image with the ELL pre-requisites
- Builds ELL and runs `ctest -VV`

The Travis CI jobs currently fail due to a pre-existing issue.  This is addressed in #154.

Verified on my fork that both #155 and #154 combined will result in a passing Travis build: [![Build Status](https://travis-ci.com/lisaong/ELL.svg?branch=master)](https://travis-ci.com/lisaong/ELL)