### PR TITLE
Build status in README.md, fix travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
   - docker pull $DOCKERHUB_ACCOUNT/ell-build:latest
 
 script:
-  - docker run -v $TRAVIS_BUILD_DIR:/ELL -it $DOCKERHUB_ACCOUNT/ell-build:latest /bin/sh -c 'cd /ELL; ./build.sh; cd build; ctest -VV'
+  - docker run -v $TRAVIS_BUILD_DIR:/ELL -it $DOCKERHUB_ACCOUNT/ell-build:latest /bin/sh -c 'cd /ELL; ./build.sh build 1; cd build; ctest -VV'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 ## Build and Installation Instructions
 
+[![Build Status](https://travis-ci.com/lisaong/ELL.svg?branch=master)](https://travis-ci.com/lisaong/ELL)
+
 * [Windows](INSTALL-Windows.md)
 * [Ubuntu Linux](INSTALL-Ubuntu.md)
 * [Mac OS X](INSTALL-Mac.md)


### PR DESCRIPTION
Display build status in main README.md

Ensure build.sh is called with 1 proc, since travis docker environment may run out of memory